### PR TITLE
A fix for bleeding edge clang (#187)

### DIFF
--- a/include/hydrogen/utils/HalfPrecision.hpp
+++ b/include/hydrogen/utils/HalfPrecision.hpp
@@ -129,7 +129,7 @@ struct TypeTraits<gpu_half_type>
 
 }// namespace hydrogen
 
-#if defined(HYDROGEN_HAVE_ROCM) || (defined(HYDROGEN_HAVE_CUDA) && !(defined(__CUDACC__)) && (CUDA_VERSION < 12020))
+#if (defined(HYDROGEN_HAVE_ROCM) && defined(__clang__) && __clang__ && __clang_major__ < 19) || (defined(HYDROGEN_HAVE_CUDA) && !(defined(__CUDACC__)) && (CUDA_VERSION < 12020))
 
 /** @brief Enable "update" functionality for __half. */
 template <typename T>


### PR DESCRIPTION
I've been working on PMR^3 recently and I'm experiencing a problem when running with hybrid build of Elemental (enabled pthreads support in PMR^3). A simple example causes a failure at some point due to passing an incorrect pointer to pthreads function. I've been really surprised to find this problem, but now I'm pretty sure that this issue is real and caused by a double destruction of a lock.

Bug confirmed with gcc 6.2 and Intel's MPI 2017.0.098
Steps to reproduce:

1. Build with EL_HYBRID=On
2. Run example HermitianTridiagEig locally with at least two MPI processes. Output suggests that an ```
incorrect value has been passed to lock function:
pthread_mutex_lock returned EINVAL
HermitianEig: [...]/Elemental/external/pmrrr/src/core/rrr.c:194: PMR_rrr_lock: Assertion 'info == 0' failed.

```
Here is what is happening, according to my logs. The problem appears for [a mutex defined in RRR structure.](https://github.com/elemental/Elemental/blob/master/external/pmrrr/include/pmrrr/rrr.h#L62)

[A new RRR instance is created and immediately after that a dependencies number is set to one](https://github.com/mcopik/Elemental/blob/master/external/pmrrr/src/plarrv.c#L374)
[This instance may be used to create a new singleton task in the queue](https://github.com/mcopik/Elemental/blob/master/external/pmrrr/src/plarrv.c#L433) Dependencies number is incremented to prevent the structure from being destroyed later. So far, so good.
[The same function tries to destroy existing instance of RRR, because a new one might have been created (e.g. for the case of a cluster)](https://github.com/mcopik/Elemental/blob/master/external/pmrrr/src/plarrv.c#L549)
[Destroying the lock is missing in original PMR^3, most likely causing a memory leak. Refactorization done for Elemental has introduced proper cleaning of lock, but it is being done even if the RRR structure is still active! (number of dependencies > 1)](https://github.com/elemental/Elemental/blob/master/external/pmrrr/src/core/rrr.c#L194)
[At some point the singleton task is consumed](https://github.com/mcopik/Elemental/blob/master/external/pmrrr/src/plarrv.c#L594)
[And first attempt to use the lock, this time for locking in the same destroy function, gives an incorrect return value from pthread's function](https://github.com/mcopik/Elemental/blob/master/external/pmrrr/src/process_s_task.c#L307)
A bugfix is very simple: move destroy_lock to if case where RRR is destroyed completely. After that change I was not able to reproduce this issue.